### PR TITLE
Allow virtualenv to use system wide packages

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -42,7 +42,7 @@ then
 	sudo mkdir -p $final_path
 fi
 sudo cp -r ../sources/* $final_path
-sudo virtualenv $final_path
+sudo virtualenv --system-site-packages $final_path
 sudo bash -c "source $final_path/bin/activate && pip install -r $final_path/requirements.txt"
 
 # Disable swapfile


### PR DESCRIPTION
This fix the installation on some architecture by avoiding to compile lxml and also on architecture with low available ram (like the internet cube).